### PR TITLE
undefined method `write_inheritable_hash' for ActiveRecord::Base:Class (NoMethodError)

### DIFF
--- a/lib/has_many_polymorphs/reflection.rb
+++ b/lib/has_many_polymorphs/reflection.rb
@@ -16,7 +16,12 @@ module ActiveRecord #:nodoc:
           when :has_many_polymorphs
             reflection = PolymorphicReflection.new(macro, name, options, active_record)
         end
-        write_inheritable_hash :reflections, name => reflection
+
+	class_attribute :reflections
+	self.reflections = name => reflection
+
+	# DEPRICATED for Rails 3.2
+        #write_inheritable_hash :reflections, name => reflection
         reflection
       end
 

--- a/lib/has_many_polymorphs/reflection.rb
+++ b/lib/has_many_polymorphs/reflection.rb
@@ -22,7 +22,7 @@ module ActiveRecord #:nodoc:
 
 	# DEPRICATED for Rails 3.2
         #write_inheritable_hash :reflections, name => reflection
-        reflection
+        reflections
       end
 
     end

--- a/lib/has_many_polymorphs/reflection.rb
+++ b/lib/has_many_polymorphs/reflection.rb
@@ -16,7 +16,12 @@ module ActiveRecord #:nodoc:
           when :has_many_polymorphs
             reflection = PolymorphicReflection.new(macro, name, options, active_record)
         end
-        write_inheritable_hash :reflections, name => reflection
+
+	class_attribute :reflections
+	self.reflections = reflection
+
+	# DEPRICATED for Rails 3.2
+        #write_inheritable_hash :reflections, name => reflection
         reflection
       end
 


### PR DESCRIPTION
For Rails 3.2 write_inheritable_hash is Depricated change with

class_attribute :attribute_name
self.attribute_name = value
